### PR TITLE
Cleanup

### DIFF
--- a/lib/cookbook.rb
+++ b/lib/cookbook.rb
@@ -1,5 +1,6 @@
 class Cookbook
   attr_reader :recipes
+  
   def initialize
     @recipes = []
   end

--- a/lib/cookbook.rb
+++ b/lib/cookbook.rb
@@ -5,7 +5,7 @@ class Cookbook
   end
 
   def add_recipe(recipe)
-    @recipes << recipe
+    !@recipes.include?(recipe) ? @recipes << recipe : @recipes
   end
 
   def summary

--- a/lib/ingredient.rb
+++ b/lib/ingredient.rb
@@ -2,6 +2,7 @@ class Ingredient
   attr_reader :name,
               :unit,
               :calories
+              
   def initialize(name,unit,calories)
     @name = name
     @unit = unit

--- a/lib/pantry.rb
+++ b/lib/pantry.rb
@@ -1,5 +1,6 @@
 class Pantry
   attr_reader :stock
+  
   def initialize
     @stock = Hash.new {|hash,key| hash[key] = 0}
   end

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -28,11 +28,10 @@ class Recipe
   end
 
   def details
-    details_hash = {ingredients: [],total_calories: 0}
+    details_hash = {ingredients: [],total_calories: total_calories}
     @ingredients_required.each do |ingredient,amount|
       details_hash[:ingredients] << ingredient_hash(ingredient)
     end
-    details_hash[:total_calories] += total_calories
     details_hash
   end
 

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -15,10 +15,6 @@ class Recipe
     @ingredients_required[ingredient]
   end
 
-  def ingredients
-    @ingredients_required.keys
-  end
-
   def total_calories
     @ingredients_required.inject(0) do |sum,(ingredient,amount)|
       sum += ingredient.calories * amount

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -32,12 +32,12 @@ class Recipe
   end
 
   def details
-    hash = {ingredients: [],total_calories: 0}
+    details_hash = {ingredients: [],total_calories: 0}
     @ingredients_required.each do |ingredient,amount|
-      hash[:ingredients] << ingredient_hash(ingredient)
+      details_hash[:ingredients] << ingredient_hash(ingredient)
     end
-    hash[:total_calories] += total_calories
-    hash
+    details_hash[:total_calories] += total_calories
+    details_hash
   end
 
   def summary

--- a/test/cookbook_test.rb
+++ b/test/cookbook_test.rb
@@ -42,16 +42,21 @@ class CookbookTest < MiniTest::Test
     expected = [{
                 name:"Mac and Cheese",
                 details: {
-                  ingredients: [{ingredient: "Cheese",
+                  ingredients: [{
+                                ingredient: "Cheese",
                                 amount: "2 C"},
-                                {ingredient: "Macaroni",
+                                {
+                                ingredient: "Macaroni",
                                 amount: "8 oz"}],
                   total_calories: 440}},
-                {name: "Burger",
+                {
+                name: "Burger",
                 details:{
-                  ingredients: [{ingredient: "Ground Beef",
+                  ingredients: [{
+                                ingredient: "Ground Beef",
                                 amount: "4 oz"},
-                                {ingredient: "Bun",
+                                {
+                                ingredient: "Bun",
                                 amount: "100 g"}],
                   total_calories: 500}}]
     assert_equal expected, @cookbook.summary

--- a/test/cookbook_test.rb
+++ b/test/cookbook_test.rb
@@ -29,6 +29,13 @@ class CookbookTest < MiniTest::Test
     assert_equal [@mac_and_cheese,@burger], @cookbook.recipes
   end
 
+  def test_cookbook_cannot_have_duplicate_recipes
+    @cookbook.add_recipe(@mac_and_cheese)
+    @cookbook.add_recipe(@burger)
+    @cookbook.add_recipe(@burger)
+    assert_equal [@mac_and_cheese,@burger], @cookbook.recipes
+  end
+
   def test_cookbook_can_print_summary_of_recipes
     @cookbook.add_recipe(@mac_and_cheese)
     @cookbook.add_recipe(@burger)

--- a/test/pantry_test.rb
+++ b/test/pantry_test.rb
@@ -36,5 +36,4 @@ class PantryTest < MiniTest::Test
     @pantry.restock(@mac,8)
     assert_equal true, @pantry.enough_ingredients_for?(@mac_and_cheese)
   end
-
 end

--- a/test/recipe_test.rb
+++ b/test/recipe_test.rb
@@ -38,10 +38,6 @@ class RecipeTest < MiniTest::Test
     assert_equal 8, @mac_and_cheese.amount_required(@mac)
   end
 
-  def test_recipe_can_list_ingredients
-    assert_equal [@cheese,@mac], @mac_and_cheese.ingredients
-  end
-
   def test_recipe_can_show_total_calories
     assert_equal 440, @mac_and_cheese.total_calories
   end

--- a/test/recipe_test.rb
+++ b/test/recipe_test.rb
@@ -5,6 +5,8 @@ class RecipeTest < MiniTest::Test
     @cheese = Ingredient.new("Cheese","C",100)
     @mac = Ingredient.new("Macaroni","oz",30)
     @mac_and_cheese = Recipe.new("Mac and Cheese")
+    @mac_and_cheese.add_ingredient(@cheese,2)
+    @mac_and_cheese.add_ingredient(@mac,8)
   end
 
   def test_recipe_exists
@@ -16,47 +18,41 @@ class RecipeTest < MiniTest::Test
   end
 
   def test_recipe_starts_with_no_ingredients_by_default
-    assert_equal ({}), @mac_and_cheese.ingredients_required
+    mac_and_cheese = Recipe.new("Mac and Cheese")
+    assert_equal ({}), mac_and_cheese.ingredients_required
   end
 
   def test_recipe_can_have_ingredients_added
-    @mac_and_cheese.add_ingredient(@cheese,2)
-    @mac_and_cheese.add_ingredient(@mac,8)
-    expected = {@cheese => 2,
-                @mac => 8}
-    assert_equal expected, @mac_and_cheese.ingredients_required
+    cheese = Ingredient.new("Cheese","C",100)
+    mac = Ingredient.new("Macaroni","oz",30)
+    mac_and_cheese = Recipe.new("Mac and Cheese")
+    mac_and_cheese.add_ingredient(cheese,2)
+    mac_and_cheese.add_ingredient(mac,8)
+    expected = {cheese => 2,
+                mac => 8}
+    assert_equal expected, mac_and_cheese.ingredients_required
   end
 
   def test_recipe_can_find_amount_required_for_ingredient
-    @mac_and_cheese.add_ingredient(@cheese,2)
-    @mac_and_cheese.add_ingredient(@mac,8)
     assert_equal 2, @mac_and_cheese.amount_required(@cheese)
     assert_equal 8, @mac_and_cheese.amount_required(@mac)
   end
 
   def test_recipe_can_list_ingredients
-    @mac_and_cheese.add_ingredient(@cheese,2)
-    @mac_and_cheese.add_ingredient(@mac,8)
     assert_equal [@cheese,@mac], @mac_and_cheese.ingredients
   end
 
   def test_recipe_can_show_total_calories
-    @mac_and_cheese.add_ingredient(@cheese,2)
-    @mac_and_cheese.add_ingredient(@mac,8)
     assert_equal 440, @mac_and_cheese.total_calories
   end
 
   def test_recipe_can_print_ingredient_hash
-    @mac_and_cheese.add_ingredient(@cheese,2)
-    @mac_and_cheese.add_ingredient(@mac,8)
     expected = {ingredient:"Cheese",
                 amount: "2 C"}
     assert_equal expected, @mac_and_cheese.ingredient_hash(@cheese)
   end
 
   def test_recipe_can_print_recipe_details
-    @mac_and_cheese.add_ingredient(@cheese,2)
-    @mac_and_cheese.add_ingredient(@mac,8)
     expected = {
       ingredients: [{ingredient: "Cheese",
                       amount: "2 C"},
@@ -67,8 +63,6 @@ class RecipeTest < MiniTest::Test
   end
 
   def test_recipe_can_print_recipe_summary
-    @mac_and_cheese.add_ingredient(@cheese,2)
-    @mac_and_cheese.add_ingredient(@mac,8)
     expected = {name:"Mac and Cheese",
                 details: {
                   ingredients: [{ingredient: "Cheese",


### PR DESCRIPTION
Makes it so a Cookbook can't have duplicate recipes added.
I did not do this for add_ingredient to Recipes because sometimes you need the same ingredient twice for different parts of the recipe (i.e. butter to saute with, butter to mix in).

Cleans up whitespace and methods.